### PR TITLE
Python 3 support

### DIFF
--- a/pymetamap/MetaMap.py
+++ b/pymetamap/MetaMap.py
@@ -24,7 +24,7 @@ class MetaMap:
     """
     __metaclass__ = abc.ABCMeta
     def __init__(self, metamap_filename, version=None):
-        self.metamap_filename = metamap_filename
+        self.metamap_filename = str(metamap_filename)
         if version is None:
             version = DEFAULT_METAMAP_VERSION
 

--- a/pymetamap/SubprocessBackend.py
+++ b/pymetamap/SubprocessBackend.py
@@ -77,10 +77,10 @@ class SubprocessBackend(MetaMap):
             if sentences is not None:
                 if ids is not None:
                     for identifier, sentence in zip(ids, sentences):
-                        input_file.write(b'%r|%r\n' % (identifier, sentence))
+                        input_file.write('{0!r}|{1!r}\n'.format(identifier, sentence).encode('utf8'))
                 else:
                     for sentence in sentences:
-                        input_file.write(b'%r\n' % sentence)
+                        input_file.write('{0!r}\n'.format(sentence).encode('utf8'))
                 input_file.flush()
 
             command = [self.metamap_filename, '-N']


### PR DESCRIPTION
Hi,

This pull requests fixes #11 
I tested it on python 3.4.3 and python 2.7.6.

In addition, the `str(metamap_filename)` conversion makes it possible to work with Pathlib's filenames in python 3.4