### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
-/dists/
 /*.egg-info
+build/
+dist/


### PR DESCRIPTION
I installed this as a submodule to my project. After running `python setup.py install`, it created two directories: 

```
build
dist
```

<img width="662" alt="screen shot 2017-07-21 at 3 46 19 pm" src="https://user-images.githubusercontent.com/4664374/28479848-37fdf628-6e2c-11e7-81fa-1114a8e04b97.png">


Adding this to the `.gitignore` and removed the `dists` directory