### PR TITLE
added no_nums arg

### DIFF
--- a/pymetamap/SubprocessBackend.py
+++ b/pymetamap/SubprocessBackend.py
@@ -25,19 +25,33 @@ class SubprocessBackend(MetaMap):
         """
         MetaMap.__init__(self, metamap_filename, version)
 
-    def extract_concepts(self, sentences=None, ids=None,
-                         composite_phrase=4, filename=None,
-                         file_format='sldi', allow_acronym_variants=False,
-                         word_sense_disambiguation=False, allow_large_n=False,
-                         strict_model=False, relaxed_model=False,
-                         allow_overmatches=False, allow_concept_gaps=False,
-                         term_processing=False, no_derivational_variants=False,
-                         derivational_variants=False, ignore_word_order=False,
+    def extract_concepts(self,
+                         sentences=None,
+                         ids=None,
+                         composite_phrase=4,
+                         filename=None,
+                         file_format='sldi',
+                         allow_acronym_variants=False,
+                         word_sense_disambiguation=False,
+                         allow_large_n=False,
+                         strict_model=False,
+                         relaxed_model=False,
+                         allow_overmatches=False,
+                         allow_concept_gaps=False,
+                         term_processing=False,
+                         no_derivational_variants=False,
+                         derivational_variants=False,
+                         ignore_word_order=False,
                          unique_acronym_variants=False,
                          prefer_multiple_concepts=False,
-                         ignore_stop_phrases=False, compute_all_mappings=False,
-                         mm_data_version=False, exclude_sources=[],
-                         restrict_to_sources=[], restrict_to_sts=[], exclude_sts=[]):
+                         ignore_stop_phrases=False,
+                         compute_all_mappings=False,
+                         mm_data_version=False,
+                         exclude_sources=[],
+                         restrict_to_sources=[],
+                         restrict_to_sts=[],
+                         exclude_sts=[],
+                         no_nums=[]):
         """ extract_concepts takes a list of sentences and ids(optional)
             then returns a list of Concept objects extracted via
             MetaMap.
@@ -64,7 +78,8 @@ class SubprocessBackend(MetaMap):
                 Restrict to Sources -R
                 Restrict to Semantic Types -J
                 Exclude Semantic Types -k
-                
+                Suppress Numerical Concepts --no_nums
+
 
             For information about the available options visit
             http://metamap.nlm.nih.gov/.
@@ -74,13 +89,11 @@ class SubprocessBackend(MetaMap):
                   returned along with the error found.
         """
         if allow_acronym_variants and unique_acronym_variants:
-            raise ValueError("You can't use both allow_acronym_variants and "
-                             "unique_acronym_variants.")
+            raise ValueError("You can't use both allow_acronym_variants and unique_acronym_variants.")
         if (sentences is not None and filename is not None) or \
                 (sentences is None and filename is None):
-            raise ValueError("You must either pass a list of sentences "
-                             "OR a filename.")
-        if file_format not in ['sldi','sldiID']:
+            raise ValueError("You must either pass a list of sentences OR a filename.")
+        if file_format not in ['sldi', 'sldiID']:
             raise ValueError("file_format must be either sldi or sldiID")
 
         input_file = None
@@ -140,8 +153,10 @@ class SubprocessBackend(MetaMap):
             if len(exclude_sts) > 0:
                 command.append('-k')
                 command.append(str(','.join(exclude_sts)))
-            if ids is not None or (file_format == 'sldiID' and
-                    sentences is None):
+            if len(no_nums) > 0:
+                command.append('--no_nums')
+                command.append(str(','.join(no_nums)))
+            if ids is not None or (file_format == 'sldiID' and sentences is None):
                 command.append('--sldiID')
             else:
                 command.append('--sldi')


### PR DESCRIPTION
This commit adds the `no_nums=[]` kwarg to extract_concepts and follows the pattern for including `--no_nums` for the CLI based on this document:
https://metamap.nlm.nih.gov/Docs/FAQ/NoNums.pdf