### PR TITLE
Update SubprocessBackendLite.py

### DIFF
--- a/pymetamap/SubprocessBackendLite.py
+++ b/pymetamap/SubprocessBackendLite.py
@@ -88,8 +88,9 @@ class SubprocessBackendLite(MetaMapLite):
 
             command.append(input_file.name)
             command.append('--overwrite')
-            #command.append('--indexdir={}data/ivf/2020AA/USAbase'.format(self.metamap_home))
-            #command.append('--specialtermsfile={}data/specialterms.txt'.format(self.metamap_home))
+            command.append('--indexdir={}data/ivf/2022AA/USAbase'.format(self.metamap_home))
+            command.append('--specialtermsfile={}data/specialterms.txt'.format(self.metamap_home))
+            command.append('--modelsdir={}data/models'.format(self.metamap_home))
             # command.append(output_file.name)
 
             output_file_name, file_extension = os.path.splitext(input_file.name)


### PR DESCRIPTION
Make this work in our use-case. This is similar with the issue here (https://github.com/AnthonyMRios/pymetamap/issues/56)

It seems like the code does not work if it is not in the metamap directory. I think we need to supply the `indexdir`, `specialtermsfile` and `modelsdir` explicitly.